### PR TITLE
Added optional "words" property in pageResults

### DIFF
--- a/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
+++ b/specification/cognitiveservices/data-plane/FormRecognizer/preview/v2.0/FormRecognizer.json
@@ -1136,6 +1136,13 @@
           "items": {
             "$ref": "#/definitions/ElementReference"
           }
+        },
+        "words": {
+          "description": "List of words in the text content of the key or value.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TextWord"
+          }
         }
       }
     },
@@ -1223,6 +1230,13 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/ElementReference"
+          }
+        },
+        "words": {
+          "description": "List of words in the text content of the cell.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TextWord"
           }
         },
         "isHeader": {


### PR DESCRIPTION
Added optional "words" property in KeyValueElement and DataTableCell objects.

### Latest improvements:
<i>MSFT employees can try out our new experience at <b>[OpenAPI Hub](https://aka.ms/openapiportal) </b> - one location for using our validation tools and finding your workflow. 
</i><br>
### Contribution checklist:
- [ ] I have reviewed the [documentation](https://github.com/Azure/azure-rest-api-specs#basics) for the workflow.
- [ ] [Validation tools](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#validation-tools-for-swagger-checklist) were run on swagger spec(s) and have all been fixed in this PR.
- [ ] The [OpenAPI Hub](https://aka.ms/openapiportal) was used for checking validation status and next steps.
### ARM API Review Checklist
- [ ] Service team MUST add the "WaitForARMFeedback" label if the management plane API changes fall into one of the below categories. 
- adding/removing APIs.
- adding/removing properties.
- adding/removing API-version. 
- adding a new service in Azure.

Failure to comply may result in delays for manifest application. Note this does not apply to data plane APIs.
- [ ] If you are blocked on ARM review and want to get the PR merged urgently, please get the ARM oncall for reviews (RP Manifest Approvers team under Azure Resource Manager service) from IcM and reach out to them. 
Please follow the link to find more details on [API review process](https://armwiki.azurewebsites.net/rp_onboarding/ResourceProviderOnboardingAPIRevieworkflow.html).
